### PR TITLE
Chore/force firebase config

### DIFF
--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -3,20 +3,24 @@ import { getApp, getApps, initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
 import { getFirestore } from 'firebase/firestore';
 
+// ⚠️ PRUEBA CONTROLADA: valores literales (del snippet oficial)
 const config = {
-  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
-  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
-  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
-  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
-  appId: import.meta.env.VITE_FIREBASE_APP_ID,
-  measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID,
+  apiKey: "AIzaSyBp2bEoUGYUZ_oz4TZXMVeHUiq-w76LFEo",
+  authDomain: "premios-paramo-938eb.firebaseapp.com",
+  projectId: "premios-paramo-938eb",
+  storageBucket: "premios-paramo-938eb.firebasestorage.app",
+  messagingSenderId: "298114311534",
+  appId: "1:298114311534:web:43f7c9f3b9b62565c5cd7f",
+  measurementId: "G-H3YP0KL2K4",
 };
 
-// Debug temporal (puedes quitarlo luego)
+// Log temporal para confirmar que llegan literales
 if (typeof window !== 'undefined') {
-  console.log('[firebase][client] apiKey prefix:', (config.apiKey ?? '').slice(0, 6));
-  console.log('[firebase][client] authDomain:', config.authDomain);
+  console.log('[firebase][client][FORCED]', {
+    apiKey: config.apiKey.slice(0, 6) + '...',
+    authDomain: config.authDomain,
+    projectId: config.projectId,
+  });
 }
 
 const app = getApps().length ? getApp() : initializeApp(config);


### PR DESCRIPTION
Se actualizó el archivo src/lib/firebase.ts para forzar el uso de la Firebase API Key correcta directamente en el código, con el fin de probar y resolver el error auth/invalid-api-key que estaba impidiendo el inicio de sesión.

Contexto

GitHub detectó la clave pública de Firebase como “secreto expuesto”, pero esta clave no compromete la seguridad porque siempre se expone en aplicaciones web.

El objetivo de este cambio es verificar en producción si el login ya funciona con la API key explícita.