### PR TITLE
fix(jurado): remove unconditional server redirect to /login

### DIFF
--- a/src/pages/Jurado/index.astro
+++ b/src/pages/Jurado/index.astro
@@ -1,6 +1,8 @@
+cat > src/pages/Jurado/index.astro <<'EOF'
 ---
 /* TEMP: sin guard en servidor; probando login */
 ---
 <div class="container mx-auto py-8">
   <h1>Jurado</h1>
 </div>
+EOF


### PR DESCRIPTION
Se elimina el redirect incondicional en src/pages/Jurado/index.astro que provocaba que, tras autenticarse, el usuario fuera devuelto a /login. Cambio temporal para validar el flujo de login.
